### PR TITLE
fix: use yarn in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - name: Install dependencies
-        run: npm i
-      - run: npm run build
+        run: yarn
+      - run: yarn build
 
   release:
     name: Semantic Release
@@ -35,7 +36,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
-      - run: npm ci
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,17 +34,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
       - name: Install node modules
         shell: bash
-        run: npm i
+        run: yarn
 
       - name: Unit testing
         shell: bash
-        run: npm run test:unit
+        run: yarn test:unit
 
       # Only run integration tests in one version, the current tests not support concurrent testing
       - name: Integration testing
         shell: bash
         if: ${{ matrix.node-version == '14.x' }}
-        run: npm run test:integration
+        run: yarn test:integration

--- a/package.json
+++ b/package.json
@@ -32,11 +32,6 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@commitlint/cli": "17.6.7",
-    "@commitlint/config-conventional": "17.6.7",
-    "@semantic-release/changelog": "6.0.3",
-    "@semantic-release/git": "10.0.1",
-    "@semantic-release/npm": "9.0.2",
     "@types/jest": "26.0.20",
     "@types/lodash": "4.14.168",
     "@types/node": "14.18.54",
@@ -45,12 +40,19 @@
     "axios": "0.21.1",
     "dotenv": "10.0.0",
     "eslint": "7.32.0",
-    "husky": "8.0.3",
+    "husky": "7.0.4",
     "jest": "26.6.3",
     "lodash": "4.17.21",
-    "semantic-release": "19.0.5",
     "ts-jest": "26.5.3",
     "ts-node": "9.1.1",
     "typescript": "4.4.4"
+  },
+  "optionalDependencies": {
+    "@commitlint/cli": "17.6.7",
+    "@commitlint/config-conventional": "17.6.7",
+    "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/git": "10.0.1",
+    "@semantic-release/npm": "9.0.2",
+    "semantic-release": "19.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,10 +3451,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+husky@7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
`npm ci` broken as we don't use package-lock.json so the pipeline will build using `yarn` instead